### PR TITLE
registerObject wrapper around registerFN

### DIFF
--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -220,6 +220,25 @@ module.exports = {
     hookUpPrototypes();
   },
 
+  registerObject(object, label) {
+
+    if(object.prototype) {
+      this.registerObject(object.prototype, label)
+    }
+
+    var functions = Object.getOwnPropertyNames(object)
+    for(var functionName of functions) {
+      var type = typeof object[functionName]
+      var extendedLabel = label + '.' + functionName
+      if(type == 'function') {
+        var originalFunction = object[functionName]
+        object[functionName] = this.registerFN(originalFunction, extendedLabel)
+      }
+    }
+
+    return object
+  },
+
   registerFN(fn, functionName) {
     if (!functionName) {
       functionName = fn.name;

--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -77,18 +77,49 @@ function wrapFunction(name, originalFunction) {
 
 function hookUpPrototypes() {
   Profiler.prototypes.forEach(function eachPrototype(proto) {
-    var foundProto = proto.val.prototype ? proto.val.prototype : proto.val;
-    Object.keys(foundProto).forEach(function eachKeyOnPrototype(prototypeFunctionName) {
-      var key = `${proto.name}.${prototypeFunctionName}`;
-      try {
-        if (typeof foundProto[prototypeFunctionName] === 'function' && prototypeFunctionName !== 'getUsedCpu') {
-          var originalFunction = foundProto[prototypeFunctionName];
-          foundProto[prototypeFunctionName] = wrapFunction(key, foundProto[prototypeFunctionName]);
-        }
-      } catch (ex) { }
-    });
+    profileObjectFunctions(proto.val, proto.name)
   });
 }
+
+function profileObjectFunctions(object, label) {
+
+  if(object.prototype) {
+    profileObjectFunctions(object.prototype, label)
+  }
+
+  var functions = Object.keys(object)
+  for(var functionName of functions) {
+    try {
+
+      if(label == 'Game' && functionName == 'getUsedCpu') {
+        continue
+      }
+
+      var type = typeof object[functionName]
+      var extendedLabel = label + '.' + functionName
+      if(type == 'function') {
+        var originalFunction = object[functionName]
+        object[functionName] = profileFunction(originalFunction, extendedLabel)
+      }
+
+    } catch (ex) { }
+  }
+
+  return object
+}
+
+function profileFunction(fn, functionName) {
+  if (!functionName) {
+    functionName = fn.name;
+  }
+  if (!functionName) {
+    console.log('Couldn\'t find a function name for - ', fn);
+    console.log('Will not profile this function.');
+  } else {
+    return wrapFunction(functionName, fn);
+  }
+}
+
 
 var Profiler = {
   printProfile() {
@@ -221,33 +252,10 @@ module.exports = {
   },
 
   registerObject(object, label) {
-
-    if(object.prototype) {
-      this.registerObject(object.prototype, label)
-    }
-
-    var functions = Object.getOwnPropertyNames(object)
-    for(var functionName of functions) {
-      var type = typeof object[functionName]
-      var extendedLabel = label + '.' + functionName
-      if(type == 'function') {
-        var originalFunction = object[functionName]
-        object[functionName] = this.registerFN(originalFunction, extendedLabel)
-      }
-    }
-
-    return object
+    return profileObjectFunctions(object, label)
   },
 
   registerFN(fn, functionName) {
-    if (!functionName) {
-      functionName = fn.name;
-    }
-    if (!functionName) {
-      console.log('Couldn\'t find a function name for - ', fn);
-      console.log('Will not profile this function.');
-    } else {
-      return wrapFunction(functionName, fn);
-    }
+    return profileFunction(fn, functionName)
   }
 };


### PR DESCRIPTION
Right now you have pass each individual function in an object to the
registerFN function to make it profile. This wrapper allows users to
pass entire objects, with each of their functions getting added to the
profiler.

This will affect both direction functions and those assigned through
the prototype attribute, allowing complex functions that work with the
“new” keyword to easily be added to the profiler.