### PR TITLE
Fix bug with getters on prototype

### DIFF
--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -107,7 +107,6 @@ function profileObjectFunctions(object, label) {
   const objectToWrap = object.prototype ? object.prototype : object;
 
   Object.getOwnPropertyNames(objectToWrap).forEach(functionName => {
-
     const isBlackListed = functionBlackList.indexOf(functionName) !== -1;
     if (isBlackListed) {
       return;

--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -107,15 +107,30 @@ function profileObjectFunctions(object, label) {
   const objectToWrap = object.prototype ? object.prototype : object;
 
   Object.getOwnPropertyNames(objectToWrap).forEach(functionName => {
+
+    const isBlackListed = functionBlackList.indexOf(functionName) !== -1;
+    if (isBlackListed) {
+      return;
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(object, functionName);
+    if (!descriptor) {
+      return;
+    }
+
+    const hasAccessor = descriptor.get || descriptor.set;
+    if (hasAccessor) {
+      return;
+    }
+
+    const isFunction = typeof descriptor.value === 'function';
+    if (!isFunction) {
+      return;
+    }
+
     const extendedLabel = `${label}.${functionName}`;
-    try {
-      const isFunction = typeof objectToWrap[functionName] === 'function';
-      const notBlackListed = functionBlackList.indexOf(functionName) === -1;
-      if (isFunction && notBlackListed) {
-        const originalFunction = objectToWrap[functionName];
-        objectToWrap[functionName] = profileFunction(originalFunction, extendedLabel);
-      }
-    } catch (e) { } /* eslint no-empty:0 */
+    const originalFunction = objectToWrap[functionName];
+    objectToWrap[functionName] = profileFunction(originalFunction, extendedLabel);
   });
 
   return objectToWrap;

--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -112,7 +112,7 @@ function profileObjectFunctions(object, label) {
       return;
     }
 
-    const descriptor = Object.getOwnPropertyDescriptor(object, functionName);
+    const descriptor = Object.getOwnPropertyDescriptor(objectToWrap, functionName);
     if (!descriptor) {
       return;
     }


### PR DESCRIPTION
ES6 getter-Functions are invoked, even when called from prototype.

In that case `this` is the prototype of the getter and not an actual object of the prototype.

This fix uses Object.getOwnPropertyDescriptor and checks if the get or set property is present.