### PR TITLE
Add profiling for getters and setters

### DIFF
--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -107,7 +107,6 @@ function profileObjectFunctions(object, label) {
   const objectToWrap = object.prototype ? object.prototype : object;
 
   Object.getOwnPropertyNames(objectToWrap).forEach(functionName => {
-
     const isBlackListed = functionBlackList.indexOf(functionName) !== -1;
     if (isBlackListed) {
       return;

--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -107,15 +107,30 @@ function profileObjectFunctions(object, label) {
   const objectToWrap = object.prototype ? object.prototype : object;
 
   Object.getOwnPropertyNames(objectToWrap).forEach(functionName => {
+
+    const isBlackListed = functionBlackList.indexOf(functionName) !== -1;
+    if (isBlackListed) {
+      return;
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(object, functionName);
+    if (!descriptor) {
+      return;
+    }
+
+    const hasAccessor = descriptor.get || descriptor.set;
+    if (hasAccessor) {
+      return;
+    }
+
+    const isFunction = typeof descriptor.value === 'function';
+    if (!isFunction) {
+      return;
+    }
+
     const extendedLabel = `${label}.${functionName}`;
-    try {
-      const isFunction = typeof objectToWrap[functionName] === 'function';
-      const notBlackListed = functionBlackList.indexOf(functionName) === -1;
-      if (isFunction && notBlackListed) {
-        const originalFunction = objectToWrap[functionName];
-        objectToWrap[functionName] = profileFunction(originalFunction, extendedLabel);
-      }
-    } catch (e) { } /* eslint no-empty:0 */
+    const originalFunction = objectToWrap[functionName];
+    objectToWrap[functionName] = profileFunction(originalFunction, extendedLabel);
   });
 
   return objectToWrap;

--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -112,7 +112,7 @@ function profileObjectFunctions(object, label) {
       return;
     }
 
-    const descriptor = Object.getOwnPropertyDescriptor(object, functionName);
+    const descriptor = Object.getOwnPropertyDescriptor(objectToWrap, functionName);
     if (!descriptor) {
       return;
     }


### PR DESCRIPTION
Builds on top of #10 as that PR kind of breaks profiling of getters.

This will only add profiling to configurable getters and setters, this has to be set `true` explicitly.

See more at [Object.defineProperty](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty).