### PR TITLE
fixed formatting errors, outputSingle and resetSingle

### DIFF
--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -159,7 +159,7 @@ const Profiler = {
     return [].concat(header, Profiler.lines().slice(0, displayresults), footer).join('\n');
   },
 
-  outputSingle(functionname ){
+  outputSingle(functionname) {
     if (!Memory.profiler || !Memory.profiler.enabledTick) {
       return 'Profiler not active.';
     }
@@ -184,6 +184,7 @@ const Profiler = {
       return 'Function does not exist.';
     }
     delete Memory.profiler.map[functionname];
+    return true;
   },
 
   lines() {

--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -31,7 +31,9 @@ function setupProfiler() {
       }
     },
     reset: resetMemory,
+    resetSingle: Profiler.resetSingle,
     output: Profiler.output,
+    outputSingle: Profiler.outputSingle,
   };
 
   overloadCPUCalc();
@@ -155,6 +157,34 @@ const Profiler = {
       `Ticks: ${elapsedTicks}`,
     ].join('\t');
     return [].concat(header, Profiler.lines().slice(0, displayresults), footer).join('\n');
+  },
+
+  outputSingle(functionname){
+    if (!Memory.profiler || !Memory.profiler.enabledTick) {
+      return 'Profiler not active.';
+    }
+    
+    if (!Memory.profiler || !Memory.profiler.map || !Memory.profiler.map[functionname]) {
+      return 'Function does not exist.';
+    }
+
+    const elapsedTicks = Game.time - Memory.profiler.enabledTick + 1;
+    const header = 'calls\t\ttime\t\tavg\t\tfunction';
+    const data = Memory.profiler.map[functionname];
+    const line = [
+        data.calls,
+        data.time.toFixed(1),
+        (data.time / data.calls).toFixed(3),
+        functionname
+      ].join('\t\t');
+    return [header, line].join('\n');
+  },
+
+  resetSingle(functionname){
+    if (!Memory.profiler || !Memory.profiler.map || !Memory.profiler.map[functionname]) {
+      return 'Function does not exist.';
+    }
+    delete Memory.profiler.map[functionname];
   },
 
   lines() {

--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -159,28 +159,27 @@ const Profiler = {
     return [].concat(header, Profiler.lines().slice(0, displayresults), footer).join('\n');
   },
 
-  outputSingle(functionname){
+  outputSingle(functionname ){
     if (!Memory.profiler || !Memory.profiler.enabledTick) {
       return 'Profiler not active.';
     }
-    
+
     if (!Memory.profiler || !Memory.profiler.map || !Memory.profiler.map[functionname]) {
       return 'Function does not exist.';
     }
 
-    const elapsedTicks = Game.time - Memory.profiler.enabledTick + 1;
     const header = 'calls\t\ttime\t\tavg\t\tfunction';
     const data = Memory.profiler.map[functionname];
     const line = [
-        data.calls,
-        data.time.toFixed(1),
-        (data.time / data.calls).toFixed(3),
-        functionname
-      ].join('\t\t');
+      data.calls,
+      data.time.toFixed(1),
+      (data.time / data.calls).toFixed(3),
+      functionname,
+    ].join('\t\t');
     return [header, line].join('\n');
   },
 
-  resetSingle(functionname){
+  resetSingle(functionname) {
     if (!Memory.profiler || !Memory.profiler.map || !Memory.profiler.map[functionname]) {
       return 'Function does not exist.';
     }


### PR DESCRIPTION
fixed formatting errors from previous attempted pull:
162:29  error  There should be no spaces inside this paren
space-in-parens
162:30  error  Missing space before opening brace
space-before-blocks
182:3   error  Expected to return a value at the end of this method
consistent-return