### PR TITLE
Fix email method.

### DIFF
--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -138,7 +138,7 @@ const Profiler = {
   },
 
   emailProfile() {
-    Game.notify(Profiler.output());
+    Profiler.output().match(/(\w|\W){1,499}/g).forEach(s => Game.notify(s));
   },
 
   output(numresults) {


### PR DESCRIPTION
`Game#notify` has a maximum character limit of 500, so nearly all profiles would get cut off. This updated method will split the profiles every 499 characters and send them as a separate character. Not the prettiest method but at least you get the whole lot.