### PR TITLE
Add some basic tests.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage/

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,5 +16,6 @@
     "arrow-body-style": 0,
     "prefer-rest-params": 0,
     "no-use-before-define": 0,
+    "strict": 0,
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+coverage/
 node_modules/
 npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ node_js:
   - '4'
   - '6'
 script:
-  - 'npm run lint'
-  - 'npm test'
+  - 'npm test && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js'

--- a/__tests__/.eslintrc
+++ b/__tests__/.eslintrc
@@ -1,0 +1,13 @@
+{
+  "globals": {
+    "after": true,
+    "afterEach": true,
+    "before": true,
+    "beforeEach": true,
+    "context": true,
+    "describe": true,
+    "expect": true,
+    "it": true,
+    "test": true,
+  }
+}

--- a/__tests__/screeps-profiler.js
+++ b/__tests__/screeps-profiler.js
@@ -1,0 +1,133 @@
+let start = Date.now();
+resetGlobals(); // needs to be called before requiring the profiler.
+const profiler = require('../screeps-profiler');
+
+beforeEach(() => {
+  resetGlobals();
+  start = Date.now();
+});
+
+function add(a, b) {
+  return a + b;
+}
+
+function returnsScope() {
+  return this;
+}
+
+describe('screeps-profiler', () => {
+  describe('profiling', () => {
+    beforeEach(() => {
+      // setup the profiler.
+      if (Game.profiler) Game.profiler.reset();
+      profiler.enable();
+      profiler.wrap(() => {});
+    });
+
+    describe('registerFN', () => {
+      it('returns a wrapped function', () => {
+        const result = profiler.registerFN(add);
+        expect(typeof result).toBe('function');
+        expect(result.profilerWrapped).toBe(true);
+      });
+
+      it('returns a function with the same scope as the one passed in', () => {
+        const passedScope = { test: 1 };
+        const result = profiler.registerFN(returnsScope.bind(passedScope));
+        expect(result()).toBe(passedScope);
+      });
+
+      it('throws an error if you attempt to double wrap a function', () => {
+        const result = profiler.registerFN(add);
+        expect(() => {
+          profiler.registerFN(result);
+        }).toThrow();
+      });
+
+      it('should attempt some toString() preservation', () => {
+        const result = profiler.registerFN(add);
+        expect(result.toString().includes(add.toString())).toBe(true);
+      });
+    });
+
+    describe('registerObject', () => {
+      it('wraps each function on an object', () => {
+        const myObject = {
+          add,
+          returnsScope,
+          doesNotCauseError: 3,
+          doesNotCauseError2: {},
+        };
+
+        profiler.registerObject(myObject);
+        expect(myObject.add.profilerWrapped).toBe(true);
+        expect(myObject.returnsScope.profilerWrapped).toBe(true);
+      });
+
+      it('correctly wraps getter/setter functions', () => {
+        let myValue = 5;
+        const myObj = {
+          get someValue() {
+            return myValue;
+          },
+          set someValue(value) {
+            myValue = value;
+          },
+        };
+
+        profiler.registerObject(myObj);
+        const descriptors = Object.getOwnPropertyDescriptor(myObj, 'someValue');
+        expect(descriptors.get.profilerWrapped).toBe(true);
+        expect(descriptors.set.profilerWrapped).toBe(true);
+        expect(myObj.someValue).toBe(5);
+        myObj.someValue = 7;
+        expect(myObj.someValue).toBe(7);
+      });
+    });
+
+    describe('registerClass', () => {
+      class MyFakeClass {
+        someFakeMethod() {
+
+        }
+      }
+      profiler.registerClass(MyFakeClass);
+      expect(MyFakeClass.prototype.someFakeMethod.profilerWrapped).toBe(true);
+    });
+
+    describe('output', () => {
+      it('correctly limits the length of the output', () => {
+        Game.profiler.profile(10);
+        let functionsWrappedAndRan = 0;
+        while (functionsWrappedAndRan < 1000) {
+          const fn = profiler.registerFN(() => {}, `someFakeName${functionsWrappedAndRan}`);
+          fn();
+          functionsWrappedAndRan++;
+        }
+        const output = profiler.output();
+        expect(output.length > 500).toBe(true);
+        expect(output.length <= 1000).toBe(true);
+      });
+    });
+  });
+});
+
+function resetGlobals() {
+  global.Game = {
+    cpu: {
+      getUsed() {
+        return Date.now() - start;
+      },
+    },
+    rooms: {},
+    time: 10,
+  };
+  global.Memory = {};
+  global.Room = {};
+  global.Structure = {};
+  global.Spawn = {};
+  global.Creep = {};
+  global.RoomPosition = {};
+  global.Source = {};
+  global.Flag = {};
+}

--- a/__tests__/screeps-profiler.js
+++ b/__tests__/screeps-profiler.js
@@ -1,3 +1,5 @@
+'use strict';
+
 let start = Date.now();
 resetGlobals(); // needs to be called before requiring the profiler.
 const profiler = require('../screeps-profiler');

--- a/__tests__/screeps-profiler.js
+++ b/__tests__/screeps-profiler.js
@@ -109,6 +109,9 @@ describe('screeps-profiler', () => {
         const output = profiler.output();
         expect(output.length > 500).toBe(true);
         expect(output.length <= 1000).toBe(true);
+        const smallerOutput = profiler.output(300);
+        expect(smallerOutput.length > 100).toBe(true);
+        expect(smallerOutput.length <= 300).toBe(true);
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A profiler designed for use in the game of Screeps.",
   "main": "screeps-profiler.js",
   "scripts": {
-    "test": "npm run lint",
+    "test": "npm run --silent lint && jest --coverage",
     "lint": "eslint ."
   },
   "repository": {
@@ -21,9 +21,13 @@
     "url": "https://github.com/gdborton/screeps-profiler/issues"
   },
   "homepage": "https://github.com/gdborton/screeps-profiler#readme",
+  "jest": {
+    "coverageReporters": ["html", "lcov"]
+  },
   "devDependencies": {
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^6.0.2",
-    "eslint-plugin-react": "^4.1.0"
+    "eslint-plugin-react": "^4.1.0",
+    "jest": "^20.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,13 @@
   },
   "homepage": "https://github.com/gdborton/screeps-profiler#readme",
   "jest": {
-    "coverageReporters": ["html", "lcov"]
+    "coverageReporters": [
+      "html",
+      "lcov"
+    ]
   },
   "devDependencies": {
+    "coveralls": "^2.13.1",
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^6.0.2",
     "eslint-plugin-react": "^4.1.0",

--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -1,3 +1,5 @@
+'use strict';
+
 let usedOnStart = 0;
 let enabled = false;
 let depth = 0;

--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -185,11 +185,11 @@ const Profiler = {
   },
 
   emailProfile() {
-    Game.notify(Profiler.output());
+    Game.notify(Profiler.output(1000));
   },
 
-  output(numresults) {
-    const displayresults = !!numresults ? numresults : 20;
+  output(passedOutputLengthLimit) {
+    const outputLengthLimit = passedOutputLengthLimit || 1000;
     if (!Memory.profiler || !Memory.profiler.enabledTick) {
       return 'Profiler not active.';
     }
@@ -203,7 +203,23 @@ const Profiler = {
       `Total: ${Memory.profiler.totalTime.toFixed(2)}`,
       `Ticks: ${elapsedTicks}`,
     ].join('\t');
-    return [].concat(header, Profiler.lines().slice(0, displayresults), footer).join('\n');
+
+    const lines = [header];
+    let currentLength = header.length + 1 + footer.length;
+    const allLines = Profiler.lines();
+    let done = false;
+    while (!done) {
+      const line = allLines.shift();
+      // each line added adds the line length plus a new line character.
+      if (currentLength + line.length + 1 < outputLengthLimit) {
+        lines.push(line);
+        currentLength += line.length + 1;
+      } else {
+        done = true;
+      }
+    }
+    lines.push(footer);
+    return lines.join('\n');
   },
 
   lines() {

--- a/screeps-profiler.js
+++ b/screeps-profiler.js
@@ -2,6 +2,12 @@ let usedOnStart = 0;
 let enabled = false;
 let depth = 0;
 
+function AlreadyWrappedError() {
+  this.name = 'AlreadyWrappedError';
+  this.message = 'Error attempted to double wrap a function.';
+  this.stack = ((new Error())).stack;
+}
+
 function setupProfiler() {
   depth = 0; // reset depth, this needs to be done each tick.
   Game.profiler = {
@@ -75,6 +81,7 @@ const functionBlackList = [
 ];
 
 function wrapFunction(name, originalFunction) {
+  if (originalFunction.profilerWrapped) { throw new AlreadyWrappedError(); }
   function wrappedFunction() {
     if (Profiler.isProfiling()) {
       const nameMatchesFilter = name === getFilter();
@@ -96,6 +103,7 @@ function wrapFunction(name, originalFunction) {
     return originalFunction.apply(this, arguments);
   }
 
+  wrappedFunction.profilerWrapped = true;
   wrappedFunction.toString = () =>
     `// screeps-profiler wrapped function:\n${originalFunction.toString()}`;
 


### PR DESCRIPTION
I no longer play Screeps, but I know that the profiler is heavily depended on by the community. This is my attempt to get the repository into a better position to be handed off to the @screepers organization.

This adds some basic tests that ensure wrapping functions, object, and classes behaves correctly.  It also adds an error when users attempt to wrap functions that have already been wrapped.

It also changes the `output` function to take a character limit rather than a line limit, which should address the concerns brought up here - https://github.com/gdborton/screeps-profiler/pull/17